### PR TITLE
164936 2/2 Import versions no longer fails without properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ node {
 ```
 
 ## Release Notes
+### Version 2.6
+Fixed APAR PI85407 - Importing component versions no longer fails when runtime properties aren't provided.
+
 ### Version 2.5
 RFE 104275 - Support for Description and Application Request Properties on deployments.
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <name>IBM UrbanCode Deploy Pipeline (Build Steps) Plugin</name>
   <groupId>com.urbancode.jenkins.plugins</groupId>
   <artifactId>ibm-ucdeploy-build-steps</artifactId>
-  <version>2.5.${env.buildLife}</version>
+  <version>2.6.${env.buildLife}</version>
   <packaging>hpi</packaging>
   <url>https://developer.ibm.com/urbancode/plugin/jenkins/</url>
 


### PR DESCRIPTION
This change rebuilds the plugin with the updated uDeployRestClient.jar.
The uDeployRestClient project must be merged beforehand.